### PR TITLE
feat: added transactions dsl for gatling scenarios

### DIFF
--- a/src/main/scala/ru/tinkoff/gatling/transactions/Predef.scala
+++ b/src/main/scala/ru/tinkoff/gatling/transactions/Predef.scala
@@ -1,0 +1,30 @@
+package ru.tinkoff.gatling.transactions
+
+import io.gatling.commons.validation.SuccessWrapper
+import io.gatling.core.Predef.Simulation
+import io.gatling.core.protocol.Protocol
+import io.gatling.core.session.Expression
+import io.gatling.core.structure.{PopulationBuilder, ScenarioBuilder}
+import ru.tinkoff.gatling.transactions.actions.builders._
+
+object Predef {
+  abstract class SimulationWithTransactions extends Simulation {
+    override def setUp(populationBuilders: List[PopulationBuilder]): SetUp = {
+      super.setUp(populationBuilders)
+      new SetUpWithTransactions
+    }
+
+    private final class SetUpWithTransactions extends SetUp {
+      override def protocols(ps: Iterable[Protocol]): SetUp = super.protocols(ps ++ Seq(new TransactionsProtocol))
+    }
+  }
+
+  implicit class TransactionsOps(val scenarioBuilder: ScenarioBuilder) extends AnyVal {
+    def startTransaction(tName: Expression[String]): ScenarioBuilder =
+      scenarioBuilder.exec(StartTransactionActionBuilder(tName))
+
+    def endTransaction(tName: Expression[String],
+                       stopTime: Expression[Long] = _ => System.currentTimeMillis().success): ScenarioBuilder =
+      scenarioBuilder.exec(EndTransactionActionBuilder(tName, stopTime))
+  }
+}

--- a/src/main/scala/ru/tinkoff/gatling/transactions/TransactionTracker.scala
+++ b/src/main/scala/ru/tinkoff/gatling/transactions/TransactionTracker.scala
@@ -1,0 +1,12 @@
+package ru.tinkoff.gatling.transactions
+
+import akka.actor.ActorRef
+import io.gatling.core.action.Action
+import io.gatling.core.session.Session
+
+class TransactionTracker(transactionActor: ActorRef) {
+  def startTransaction(name: String, timestamp: Long): Unit =
+    transactionActor ! TransactionsActor.TransactionStarted(name, timestamp)
+  def endTransaction(name: String, timestamp: Long, session: Session, next: Action): Unit =
+    transactionActor ! TransactionsActor.TransactionEnded(name, timestamp, session, next)
+}

--- a/src/main/scala/ru/tinkoff/gatling/transactions/TransactionsActor.scala
+++ b/src/main/scala/ru/tinkoff/gatling/transactions/TransactionsActor.scala
@@ -1,0 +1,60 @@
+package ru.tinkoff.gatling.transactions
+
+import akka.actor.Props
+import io.gatling.commons.stats.{KO, OK}
+import io.gatling.core.action.Action
+import io.gatling.core.akka.BaseActor
+import io.gatling.core.session.Session
+import io.gatling.core.stats.StatsEngine
+
+object TransactionsActor {
+  def props(statsEngine: StatsEngine): Props =
+    Props(new TransactionsActor(statsEngine))
+
+  case class TransactionStarted(name: String, timestamp: Long)
+  case class TransactionEnded(name: String, timestamp: Long, session: Session, next: Action)
+}
+
+class TransactionsActor(statsEngine: StatsEngine) extends BaseActor {
+
+  private def crash(prefix: String, errorMsg: String, session: Session, next: Action): Unit = {
+    statsEngine.logCrash(session.scenario, session.groups, prefix, errorMsg)
+    next ! session.markAsFailed
+  }
+
+  private def executeNext(name: String, startTimestamp: Long, stopTimestamp: Long, session: Session, next: Action): Unit = {
+    statsEngine.logResponse(
+      session.scenario,
+      session.groups,
+      name,
+      startTimestamp,
+      stopTimestamp,
+      if (session.isFailed) KO else OK,
+      None,
+      if (session.isFailed) Some(s"transaction '$name' failed") else None
+    )
+    next ! session.logGroupRequestTimings(startTimestamp, stopTimestamp)
+  }
+
+  def onTransaction(transactionsStack: List[TransactionsActor.TransactionStarted]): Receive = {
+    case t: TransactionsActor.TransactionStarted =>
+      context.become(onTransaction(t :: transactionsStack))
+    case TransactionsActor.TransactionEnded(name, timestamp, session, next) =>
+      transactionsStack match {
+        case Nil =>
+          crash(s"Transaction '$name' close error", s"transaction '$name' wasn't started", session, next)
+
+        case started :: newStack =>
+          if (started.timestamp > timestamp) {
+            crash(s"Transaction '$name' illegal state", s"transaction not be able end before they started", session, next)
+          } else if (started.name == name) {
+            executeNext(name, started.timestamp, timestamp, session, next)
+          } else {
+            crash(s"Transaction '$name' close error", s"has unclosed transaction ${started.name}", session, next)
+          }
+          context.become(onTransaction(newStack))
+      }
+  }
+
+  override def receive: Receive = onTransaction(List.empty)
+}

--- a/src/main/scala/ru/tinkoff/gatling/transactions/TransactionsComponents.scala
+++ b/src/main/scala/ru/tinkoff/gatling/transactions/TransactionsComponents.scala
@@ -1,0 +1,11 @@
+package ru.tinkoff.gatling.transactions
+
+import io.gatling.core.protocol.ProtocolComponents
+import io.gatling.core.session.Session
+
+class TransactionsComponents(val transactionTracker: TransactionTracker) extends ProtocolComponents {
+
+  override def onStart: Session => Session = Session.Identity
+
+  override def onExit: Session => Unit = ProtocolComponents.NoopOnExit
+}

--- a/src/main/scala/ru/tinkoff/gatling/transactions/TransactionsProtocol.scala
+++ b/src/main/scala/ru/tinkoff/gatling/transactions/TransactionsProtocol.scala
@@ -1,0 +1,24 @@
+package ru.tinkoff.gatling.transactions
+
+import io.gatling.core.CoreComponents
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.protocol.{Protocol, ProtocolKey}
+
+object TransactionsProtocol {
+  val key: ProtocolKey[TransactionsProtocol, TransactionsComponents] =
+    new ProtocolKey[TransactionsProtocol, TransactionsComponents] {
+      override def protocolClass: Class[Protocol] = classOf[TransactionsProtocol].asInstanceOf[Class[Protocol]]
+
+      override def defaultProtocolValue(configuration: GatlingConfiguration): TransactionsProtocol = new TransactionsProtocol
+
+      override def newComponents(coreComponents: CoreComponents): TransactionsProtocol => TransactionsComponents =
+        _ => {
+          val transactionsActor = coreComponents.actorSystem.actorOf(TransactionsActor.props(coreComponents.statsEngine))
+          new TransactionsComponents(new TransactionTracker(transactionsActor))
+        }
+    }
+}
+
+final class TransactionsProtocol extends Protocol {
+  type Components = TransactionsComponents
+}

--- a/src/main/scala/ru/tinkoff/gatling/transactions/actions/EndTransactionAction.scala
+++ b/src/main/scala/ru/tinkoff/gatling/transactions/actions/EndTransactionAction.scala
@@ -1,0 +1,29 @@
+package ru.tinkoff.gatling.transactions.actions
+
+import io.gatling.core.action.{Action, ChainableAction}
+import io.gatling.core.controller.throttle.Throttler
+import io.gatling.core.session.{Expression, Session}
+import io.gatling.core.structure.ScenarioContext
+import io.gatling.core.util.NameGen
+import ru.tinkoff.gatling.transactions.TransactionsProtocol
+
+class EndTransactionAction(transactionName: Expression[String],
+                           stopTime: Expression[Long],
+                           ctx: ScenarioContext,
+                           val next: Action)
+    extends ChainableAction with NameGen {
+
+  override def name: String                = genName("endTransactionAction")
+  private val components                   = ctx.protocolComponentsRegistry.components(TransactionsProtocol.key)
+  private val throttler: Option[Throttler] = ctx.coreComponents.throttler
+
+  override protected def execute(session: Session): Unit =
+    for {
+      resolvedName  <- transactionName(session)
+      stopTimestamp <- stopTime(session)
+    } yield
+      throttler.fold(components.transactionTracker.endTransaction(resolvedName, stopTimestamp, session, next))(
+        _.throttle(session.scenario, () => {
+          components.transactionTracker.endTransaction(resolvedName, stopTimestamp, session, next)
+        }))
+}

--- a/src/main/scala/ru/tinkoff/gatling/transactions/actions/StartTransactionAction.scala
+++ b/src/main/scala/ru/tinkoff/gatling/transactions/actions/StartTransactionAction.scala
@@ -1,0 +1,31 @@
+package ru.tinkoff.gatling.transactions.actions
+
+import io.gatling.commons.validation._
+import io.gatling.core.action.{Action, ChainableAction}
+import io.gatling.core.controller.throttle.Throttler
+import io.gatling.core.session.{Expression, Session}
+import io.gatling.core.structure.ScenarioContext
+import io.gatling.core.util.NameGen
+import ru.tinkoff.gatling.transactions.TransactionsProtocol
+
+class StartTransactionAction(transactionName: Expression[String], ctx: ScenarioContext, val next: Action)
+    extends ChainableAction with NameGen {
+
+  override def name: String                = genName("startTransactionAction")
+  private val components                   = ctx.protocolComponentsRegistry.components(TransactionsProtocol.key)
+  private val throttler: Option[Throttler] = ctx.coreComponents.throttler
+
+  private def startAndNext(tName: String, startTimestamp: Long, session: Session): Unit = {
+    components.transactionTracker.startTransaction(tName, startTimestamp)
+    next ! session
+  }
+
+  override protected def execute(session: Session): Unit =
+    for {
+      resolvedName   <- transactionName(session)
+      startTimestamp <- ctx.coreComponents.clock.nowMillis.success
+    } yield
+      throttler.fold(startAndNext(resolvedName, startTimestamp, session))(_.throttle(session.scenario, () => {
+        startAndNext(resolvedName, startTimestamp, session)
+      }))
+}

--- a/src/main/scala/ru/tinkoff/gatling/transactions/actions/builders.scala
+++ b/src/main/scala/ru/tinkoff/gatling/transactions/actions/builders.scala
@@ -1,0 +1,15 @@
+package ru.tinkoff.gatling.transactions.actions
+import io.gatling.core.action.Action
+import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.session.Expression
+import io.gatling.core.structure.ScenarioContext
+
+object builders {
+  final case class StartTransactionActionBuilder(tName: Expression[String]) extends ActionBuilder {
+    override def build(ctx: ScenarioContext, next: Action): Action = new StartTransactionAction(tName, ctx, next)
+  }
+
+  final case class EndTransactionActionBuilder(tName: Expression[String], stopTime: Expression[Long]) extends ActionBuilder {
+    override def build(ctx: ScenarioContext, next: Action): Action = new EndTransactionAction(tName, stopTime, ctx, next)
+  }
+}

--- a/src/test/scala/ru/tinkoff/gatling/transactions/FakeEventLoop.scala
+++ b/src/test/scala/ru/tinkoff/gatling/transactions/FakeEventLoop.scala
@@ -1,0 +1,79 @@
+package ru.tinkoff.gatling.transactions
+
+import java.{util => ju}
+import java.util.{Timer, TimerTask, concurrent => juc}
+
+import io.netty.channel.{Channel, ChannelFuture, ChannelPromise, EventLoop, EventLoopGroup}
+import io.netty.util.concurrent.{EventExecutor, Future => NFuture, ProgressivePromise, Promise, ScheduledFuture}
+
+class FakeEventLoop extends EventLoop {
+  private var timerInitialized = false
+  private lazy val timer = {
+    timerInitialized = true
+    new Timer(true)
+  }
+
+  override def inEventLoop(): Boolean = true
+  override def schedule(command: Runnable, delay: Long, unit: juc.TimeUnit): ScheduledFuture[_] = {
+    timer.schedule(
+      new TimerTask {
+        override def run(): Unit = { command.run() }
+      },
+      unit.toMillis(delay)
+    )
+    null
+  }
+  override def execute(command: Runnable): Unit = command.run()
+
+  override def shutdownGracefully(): NFuture[_] = {
+    if (timerInitialized) {
+      timer.cancel()
+    }
+    null
+  }
+
+  override def parent(): EventLoopGroup                                           = throw new UnsupportedOperationException
+  override def next(): EventLoop                                                  = throw new UnsupportedOperationException
+  override def register(channel: Channel): ChannelFuture                          = throw new UnsupportedOperationException
+  override def register(promise: ChannelPromise): ChannelFuture                   = throw new UnsupportedOperationException
+  override def register(channel: Channel, promise: ChannelPromise): ChannelFuture = throw new UnsupportedOperationException
+  override def inEventLoop(thread: Thread): Boolean                               = throw new UnsupportedOperationException
+  override def newPromise[V](): Promise[V]                                        = throw new UnsupportedOperationException
+  override def newProgressivePromise[V](): ProgressivePromise[V]                  = throw new UnsupportedOperationException
+  override def newSucceededFuture[V](result: V): NFuture[V]                       = throw new UnsupportedOperationException
+  override def newFailedFuture[V](cause: Throwable): NFuture[V]                   = throw new UnsupportedOperationException
+  override def isShuttingDown: Boolean                                            = throw new UnsupportedOperationException
+  override def shutdownGracefully(quietPeriod: Long, timeout: Long, unit: juc.TimeUnit): NFuture[_] =
+    throw new UnsupportedOperationException
+  override def terminationFuture(): NFuture[_]                  = throw new UnsupportedOperationException
+  override def shutdown(): Unit                                 = throw new UnsupportedOperationException
+  override def shutdownNow(): ju.List[Runnable]                 = throw new UnsupportedOperationException
+  override def iterator(): ju.Iterator[EventExecutor]           = throw new UnsupportedOperationException
+  override def submit(task: Runnable): NFuture[_]               = throw new UnsupportedOperationException
+  override def submit[T](task: Runnable, result: T): NFuture[T] = throw new UnsupportedOperationException
+  override def submit[T](task: juc.Callable[T]): NFuture[T]     = throw new UnsupportedOperationException
+  override def schedule[V](callable: juc.Callable[V], delay: Long, unit: juc.TimeUnit): ScheduledFuture[V] =
+    throw new UnsupportedOperationException
+  override def scheduleAtFixedRate(command: Runnable,
+                                   initialDelay: Long,
+                                   period: Long,
+                                   unit: juc.TimeUnit): ScheduledFuture[_] =
+    throw new UnsupportedOperationException
+  override def scheduleWithFixedDelay(command: Runnable,
+                                      initialDelay: Long,
+                                      delay: Long,
+                                      unit: juc.TimeUnit): ScheduledFuture[_] =
+    throw new UnsupportedOperationException
+  override def isShutdown: Boolean                                          = false
+  override def isTerminated: Boolean                                        = throw new UnsupportedOperationException
+  override def awaitTermination(timeout: Long, unit: juc.TimeUnit): Boolean = throw new UnsupportedOperationException
+  override def invokeAll[T](tasks: ju.Collection[_ <: juc.Callable[T]]): ju.List[juc.Future[T]] =
+    throw new UnsupportedOperationException
+  override def invokeAll[T](tasks: ju.Collection[_ <: juc.Callable[T]],
+                            timeout: Long,
+                            unit: juc.TimeUnit): ju.List[juc.Future[T]] =
+    throw new UnsupportedOperationException
+  override def invokeAny[T](tasks: ju.Collection[_ <: juc.Callable[T]]): T = throw new UnsupportedOperationException
+  override def invokeAny[T](tasks: ju.Collection[_ <: juc.Callable[T]], timeout: Long, unit: juc.TimeUnit): T =
+    throw new UnsupportedOperationException
+}

--- a/src/test/scala/ru/tinkoff/gatling/transactions/Mocks.scala
+++ b/src/test/scala/ru/tinkoff/gatling/transactions/Mocks.scala
@@ -1,0 +1,50 @@
+package ru.tinkoff.gatling.transactions
+import akka.actor.{ActorRef, ActorSystem}
+import io.gatling.commons.util.DefaultClock
+import io.gatling.core.CoreComponents
+import io.gatling.core.pause.Disabled
+import io.gatling.core.protocol.{ProtocolComponentsRegistry, ProtocolKey}
+import io.gatling.core.structure.ScenarioContext
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterAll
+
+import scala.collection.mutable
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+trait Mocks extends MockFactory with BeforeAndAfterAll {
+
+  private val testActorSystem: ActorSystem = ActorSystem("TestSystem")
+  val testTransactionsActor: ActorRef      = testActorSystem.actorOf(TransactionsActor.props(fixtures.statsEngine))
+
+  private val protoComponents = new TransactionsComponents(new TransactionTracker(testTransactionsActor))
+
+  private val testCoreComponents = new CoreComponents(
+    testActorSystem,
+    fixtures.fakeEventLoop,
+    null,
+    None,
+    fixtures.statsEngine,
+    new DefaultClock,
+    fixtures.noAction,
+    null
+  )
+
+  val ProtocolComponentsRegistryMock: ProtocolComponentsRegistry =
+    new ProtocolComponentsRegistry(testCoreComponents, Map.empty, mutable.Map.empty) {
+      override def components[P, C](key: ProtocolKey[P, C]): C = protoComponents.asInstanceOf[C]
+    }
+
+  val testContext = new ScenarioContext(
+    testCoreComponents,
+    ProtocolComponentsRegistryMock,
+    Disabled,
+    false
+  )
+
+  override protected def afterAll(): Unit = {
+    fixtures.fakeEventLoop.shutdownGracefully()
+    Await.ready(testActorSystem.terminate(), 10.seconds)
+    super.afterAll()
+  }
+}

--- a/src/test/scala/ru/tinkoff/gatling/transactions/TransactionsSpec.scala
+++ b/src/test/scala/ru/tinkoff/gatling/transactions/TransactionsSpec.scala
@@ -1,0 +1,137 @@
+package ru.tinkoff.gatling.transactions
+
+import akka.japi.Option.Some
+import io.gatling.core.Predef._
+import io.gatling.core.action.ChainableAction
+import io.gatling.core.session.Expression
+import io.gatling.core.structure.ScenarioBuilder
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.matchers.should.Matchers
+import ru.tinkoff.gatling.transactions.Predef._
+import ru.tinkoff.gatling.transactions.actions.StartTransactionAction
+import ru.tinkoff.gatling.transactions.actions.builders._
+import ru.tinkoff.gatling.transactions.fixtures.Evt
+import org.scalatest.OptionValues._
+
+object TransactionsSpec {
+  private val now = System.currentTimeMillis()
+  val transactionScenario: ScenarioBuilder =
+    scenario("Test transaction scenario")
+      .startTransaction("t1")
+      .exec(s => s)
+      .endTransaction("t1", now + 500)
+
+  val startBuilder: StartTransactionActionBuilder = StartTransactionActionBuilder("t1")
+  val endBuilder: EndTransactionActionBuilder     = EndTransactionActionBuilder("t1", now + 500)
+
+  val transactionScenarioWithDefaultEndTime: ScenarioBuilder =
+    scenario("Test transaction scenario").startTransaction("t1").exec(s => s).endTransaction("t1")
+
+  val notOpenedTransactionScenario: ScenarioBuilder =
+    scenario("Close not opened transaction").exec(s => s).endTransaction("t1")
+
+  val incorrectEndTimeTransactionScenario: ScenarioBuilder =
+    scenario("Incorrect end time transaction")
+      .startTransaction("t1")
+      .exec(s => s)
+      .endTransaction("t1", 1L)
+
+  val incorrectTransactionSequenceScenario: ScenarioBuilder =
+    scenario("Incorrect transaction b")
+      .startTransaction("t2")
+      .exec(s => s)
+      .endTransaction("t1")
+      .endTransaction("t2")
+}
+
+class TransactionsSpec extends AnyFlatSpec with Matchers with Mocks with BeforeAndAfter {
+  import TransactionsSpec._
+
+  val tName: Symbol          = Symbol("tName")
+  val tn: Expression[String] = "t1"
+
+  "Scenario with startTransaction" should "contain start transaction action builder with specified name" in {
+    transactionScenario.actionBuilders should contain(startBuilder)
+  }
+
+  "Scenario with endTransaction" should "contain end transaction action builder with specified name" in {
+    transactionScenario.actionBuilders should contain(endBuilder)
+  }
+
+  before(fixtures.statsEngine.stop(testContext.coreComponents.controller, None))
+
+  private val session = fixtures.emptySession(transactionScenario.name)
+  private def runScenario(s: ScenarioBuilder) = {
+    val actions = s.actionBuilders.foldLeft(fixtures.noAction)(
+      (next, builder) => builder.build(testContext, next)
+    )
+    actions ! session
+    Thread.sleep(200)
+    actions
+  }
+
+  private val name     = Symbol("name")
+  private val status   = Symbol("status")
+  private val errorMsg = Symbol("errorMsg")
+
+  "Scenario with transactions after run" should "write request with correct start/stop timestamps and name" in {
+    runScenario(transactionScenarioWithDefaultEndTime)
+
+    val requestRecord: Option[Evt] = fixtures.statsEngine.getEvents.find(_.evtType == "REQUEST")
+
+    requestRecord shouldBe defined
+    requestRecord.value should have(name("t1"), status("OK"), errorMsg(None))
+    assert(requestRecord.value.startTimestamp <= requestRecord.value.endTimestamp)
+  }
+
+  "Scenario with not opened transactions after run" should "fail with transaction close error" in {
+    runScenario(notOpenedTransactionScenario)
+
+    val errorRecord: Option[Evt]   = fixtures.statsEngine.getEvents.find(_.evtType == "ERROR")
+    val requestRecord: Option[Evt] = fixtures.statsEngine.getEvents.find(_.evtType == "REQUEST")
+
+    requestRecord should not be defined
+    errorRecord shouldBe defined
+    errorRecord.value should have(
+      name("Transaction 't1' close error"),
+      status("KO"),
+    )
+    errorRecord.get.errorMsg.value shouldBe "transaction 't1' wasn't started"
+
+  }
+
+  "Scenario with a transaction that ended before it started after run" should "fail with illegal state error" in {
+    runScenario(incorrectEndTimeTransactionScenario)
+
+    val errorRecord: Option[Evt]   = fixtures.statsEngine.getEvents.find(_.evtType == "ERROR")
+    val requestRecord: Option[Evt] = fixtures.statsEngine.getEvents.find(_.evtType == "REQUEST")
+
+    requestRecord should not be defined
+    errorRecord shouldBe defined
+    errorRecord.value should have(
+      name("Transaction 't1' illegal state"),
+      status("KO"),
+    )
+    errorRecord.get.errorMsg.value shouldBe "transaction not be able end before they started"
+
+  }
+
+  "Scenario with incorrect transaction sequence after run" should "fail with transaction close error" in {
+    runScenario(incorrectTransactionSequenceScenario)
+
+    val errorRecord: Option[Evt]   = fixtures.statsEngine.getEvents.find(_.evtType == "ERROR")
+    val requestRecord: Option[Evt] = fixtures.statsEngine.getEvents.find(_.evtType == "REQUEST")
+
+    requestRecord should not be defined
+    errorRecord shouldBe defined
+    errorRecord.value should have(
+      name("Transaction 't1' close error"),
+      status("KO"),
+    )
+    errorRecord.get.errorMsg.value shouldBe "has unclosed transaction t2"
+
+  }
+
+}

--- a/src/test/scala/ru/tinkoff/gatling/transactions/fixtures.scala
+++ b/src/test/scala/ru/tinkoff/gatling/transactions/fixtures.scala
@@ -1,0 +1,65 @@
+package ru.tinkoff.gatling.transactions
+
+import akka.actor.ActorRef
+import io.gatling.commons.stats.Status
+import io.gatling.core.action.{Action, ChainableAction}
+import io.gatling.core.session.{GroupBlock, Session}
+import io.gatling.core.stats.StatsEngine
+import io.gatling.core.stats.writer.UserEndMessage
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters._
+import scala.collection.mutable
+
+object fixtures {
+  val noAction: Action = new ChainableAction {
+    override def next: Action = noAction
+
+    override def name: String = "noop"
+
+    override protected def execute(session: Session): Unit = ()
+  }
+
+  val fakeEventLoop = new FakeEventLoop
+
+  case class Evt(evtType: String,
+                 name: String,
+                 startTimestamp: Long,
+                 endTimestamp: Long,
+                 status: String,
+                 errorMsg: Option[String])
+  final class InMemoryStatsEngine extends StatsEngine {
+
+    private val events: ConcurrentLinkedQueue[Evt] = new ConcurrentLinkedQueue()
+
+    override def start(): Unit = ()
+
+    override def stop(controller: ActorRef, exception: Option[Exception]): Unit = events.clear()
+
+    override def logUserStart(scenario: String, timestamp: Long): Unit = ()
+
+    override def logUserEnd(userMessage: UserEndMessage): Unit = ()
+
+    override def logResponse(scenario: String,
+                             groups: List[String],
+                             requestName: String,
+                             startTimestamp: Long,
+                             endTimestamp: Long,
+                             status: Status,
+                             responseCode: Option[String],
+                             message: Option[String]): Unit = {
+      events.add(Evt("REQUEST", requestName, startTimestamp, endTimestamp, status.name, message))
+    }
+
+    override def logGroupEnd(scenario: String, groupBlock: GroupBlock, exitTimestamp: Long): Unit = ()
+
+    override def logCrash(scenario: String, groups: List[String], requestName: String, error: String): Unit =
+      events.add(Evt("ERROR", requestName, System.currentTimeMillis(), System.currentTimeMillis(), "KO", Some(error)))
+
+    def getEvents: List[Evt] = this.events.asScala.toList
+  }
+
+  val statsEngine = new InMemoryStatsEngine
+
+  def emptySession(scenario: String): Session = Session(scenario, 1, fakeEventLoop)
+}


### PR DESCRIPTION
This extension introduce new syntax (startTransaction/endTransaction) for gatling scenario. Transaction is union of actions, that able to measure summary response time of  actions with pauses. It is same as groups, but response time measuring include pauses and you may pass endTime manually. That make to possible write something like:
```scala
exec(Actions.createEntity())
  .startTransaction("transaction1")
  .doWhile(_("i").as[Int] < 10)(
    feed(feeder)
      .exec(Actions.insertTest())
      .pause(2)
      .exec(Actions.selectTest)
  )
  .endTransaction("transaction1")
  .exec(Actions.batchTest)
  .exec(Actions.selectAfterBatch)
```
